### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 edition = "2024"
 publish = false
 license = "MIT"
-version = "0.1.2"
+version = "0.1.3"
 repository = "https://github.com/katex-rs/katex-rs"
 
 

--- a/crates/katex/CHANGELOG.md
+++ b/crates/katex/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.3](https://github.com/katex-rs/katex-rs/compare/katex-rs-v0.1.2...katex-rs-v0.1.3) - 2025-09-30
+
+### Other
+
+- Update GitHub CI workflow for the latest features and configure release-plz


### PR DESCRIPTION



## 🤖 New release

* `katex-rs`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/katex-rs/katex-rs/compare/katex-rs-v0.1.2...katex-rs-v0.1.3) - 2025-09-30

### Other

- Update GitHub CI workflow for the latest features and configure release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).